### PR TITLE
Add backend task -- Server Group Organic groups subscribe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_source_csv": "^3.4",
         "drupal/migrate_tools": "^6.0",
+        "drupal/og": "^2.0@alpha",
         "drupal/pantheon_advanced_page_cache": "^2.2",
         "drupal/paragraphs": "^1.17",
         "drupal/paragraphs_edit": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "809b10a11d7410d781227b585a3dae4d",
+    "content-hash": "8cb082790b4252ec3a310a7876e55fe5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4428,6 +4428,109 @@
                 "source": "https://git.drupalcode.org/project/migrate_tools",
                 "issues": "https://www.drupal.org/project/issues/migrate_tools",
                 "slack": "#migrate"
+            }
+        },
+        {
+            "name": "drupal/og",
+            "version": "2.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/og.git",
+                "reference": "2.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/og-2.0.0-alpha1.zip",
+                "reference": "2.0.0-alpha1",
+                "shasum": "8716eaad445b1a909047afe6ff98cc1c1494237f"
+            },
+            "require": {
+                "drupal/core": "^10.3 || ^11"
+            },
+            "require-dev": {
+                "drupal/coder": "^8.3.16",
+                "drush/drush": "^12.5 || ^13.3",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10.5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-alpha1",
+                    "datestamp": "1744224067",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "amitaibu",
+                    "homepage": "https://www.drupal.org/u/amitaibu"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/u/mpp"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/u/pfrenssen"
+                },
+                {
+                    "name": "dries",
+                    "homepage": "https://www.drupal.org/user/1"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "Grayside",
+                    "homepage": "https://www.drupal.org/user/346868"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                },
+                {
+                    "name": "mpp",
+                    "homepage": "https://www.drupal.org/user/359881"
+                },
+                {
+                    "name": "pfrenssen",
+                    "homepage": "https://www.drupal.org/user/382067"
+                },
+                {
+                    "name": "roysegall",
+                    "homepage": "https://www.drupal.org/user/1812910"
+                },
+                {
+                    "name": "sethcohn",
+                    "homepage": "https://www.drupal.org/user/14944"
+                },
+                {
+                    "name": "Zen",
+                    "homepage": "https://www.drupal.org/user/21209"
+                }
+            ],
+            "description": "API to allow associating content with groups.",
+            "homepage": "https://drupal.org/project/og",
+            "support": {
+                "source": "https://git.drupalcode.org/project/og",
+                "issues": "https://drupal.org/project/issues/og",
+                "slack": "https://drupal.slack.com/messages/CELR48EA0"
             }
         },
         {
@@ -17553,6 +17656,7 @@
         "drupal/default_content": 15,
         "drupal/drupal_test_assertions": 20,
         "drupal/inline_entity_form": 5,
+        "drupal/og": 15,
         "drupal/potx": 15,
         "drupal/ultimate_cron": 15
     },

--- a/config/sync/block.block.server_theme_messages_in_content.yml
+++ b/config/sync/block.block.server_theme_messages_in_content.yml
@@ -1,0 +1,20 @@
+uuid: 059acd02-98bb-4dc1-a31c-677ba26d3078
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - server_theme
+id: server_theme_messages_in_content
+theme: server_theme
+region: content
+weight: -4
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/core.base_field_override.node.group.promote.yml
+++ b/config/sync/core.base_field_override.node.group.promote.yml
@@ -1,0 +1,22 @@
+uuid: ede55902-2333-4850-afaf-5be2101e1949
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node.group.promote
+field_name: promote
+entity_type: node
+bundle: group
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.entity_form_display.node.group.default.yml
+++ b/config/sync/core.entity_form_display.node.group.default.yml
@@ -1,0 +1,101 @@
+uuid: 93a11744-586e-46f8-95db-37e940c5963a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.group.body
+    - node.type.group
+  module:
+    - content_moderation
+    - path
+    - text
+id: node.group.default
+targetEntityType: node
+bundle: group
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_form_display.og_membership.default.default.yml
+++ b/config/sync/core.entity_form_display.og_membership.default.default.yml
@@ -1,0 +1,47 @@
+uuid: 1996802e-c4fa-46b1-b75f-b43744ceb06a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.og_membership.default.og_membership_request
+    - og.og_membership_type.default
+  module:
+    - og
+_core:
+  default_config_hash: C41oZuigAxSADXjhBAz-nNKO0ZyhGBcIxzKq0ORtgFk
+id: og_membership.default.default
+targetEntityType: og_membership
+bundle: default
+mode: default
+content:
+  og_membership_request:
+    type: string_textarea
+    weight: 1
+    settings:
+      rows: 2
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  roles:
+    type: options_buttons
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  state:
+    type: options_buttons
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: og_autocomplete
+    weight: -1
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      match_limit: 10
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.node.group.default.yml
+++ b/config/sync/core.entity_view_display.node.group.default.yml
@@ -1,0 +1,30 @@
+uuid: 439dc15a-eebe-42a9-8340-7eeb7c4b176f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.group.body
+    - node.type.group
+  module:
+    - text
+    - user
+id: node.group.default
+targetEntityType: node
+bundle: group
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.group.teaser.yml
+++ b/config/sync/core.entity_view_display.node.group.teaser.yml
@@ -1,0 +1,32 @@
+uuid: 23c1c718-2c32-454f-8fc3-427b898790ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.group.body
+    - node.type.group
+  module:
+    - text
+    - user
+id: node.group.teaser
+targetEntityType: node
+bundle: group
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.og_membership.default.default.yml
+++ b/config/sync/core.entity_view_display.og_membership.default.default.yml
@@ -1,0 +1,39 @@
+uuid: 1346cd52-85d5-4138-a89b-22424aaedb92
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.og_membership.default.og_membership_request
+    - og.og_membership_type.default
+_core:
+  default_config_hash: r5MkeMCbHwjFOHTONcs9jfJpNnABMJzdUJC_X9GQ-yA
+id: og_membership.default.default
+targetEntityType: og_membership
+bundle: default
+mode: default
+content:
+  og_membership_request:
+    label: above
+    type: basic_string
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  roles:
+    type: entity_reference_label
+    weight: 1
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    region: content
+  uid:
+    type: entity_reference_label
+    weight: 0
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    region: content
+hidden:
+  state: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -65,6 +65,8 @@ module:
   mysql: 0
   navigation: 0
   node: 0
+  og: 0
+  og_ui: 0
   options: 0
   page_cache: 0
   pantheon_advanced_page_cache: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -89,6 +89,7 @@ module:
   search_api_solr: 0
   seckit: 0
   select2: 0
+  server_group: 0
   server_style_guide: 0
   shortcut: 0
   simple_sitemap: 0

--- a/config/sync/field.field.node.group.body.yml
+++ b/config/sync/field.field.node.group.body.yml
@@ -1,0 +1,24 @@
+uuid: f56eb42d-b5f3-4c9e-bf9e-a951cbb35c88
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.group
+  module:
+    - text
+id: node.group.body
+field_name: body
+entity_type: node
+bundle: group
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+  allowed_formats: {  }
+field_type: text_with_summary

--- a/config/sync/field.field.og_membership.default.og_membership_request.yml
+++ b/config/sync/field.field.og_membership.default.og_membership_request.yml
@@ -1,0 +1,21 @@
+uuid: 2dabf3b4-182e-4c19-8b5a-ac9fe5ec4eca
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.og_membership.og_membership_request
+    - og.og_membership_type.default
+_core:
+  default_config_hash: nhcd7JsvjwbAHh-uYkU8--Tl9BwHVAIDVoBv9iU-P58
+id: og_membership.default.og_membership_request
+field_name: og_membership_request
+entity_type: og_membership
+bundle: default
+label: 'Request membership'
+description: 'Explain the motivation for your request to join this group.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.storage.og_membership.og_membership_request.yml
+++ b/config/sync/field.storage.og_membership.og_membership_request.yml
@@ -1,0 +1,21 @@
+uuid: 868dc222-f523-4c36-a7e0-87a39c934338
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: 5712dAes1LfhZC-TRQb-2h4elYVUxfniVafaKRVOg5Q
+id: og_membership.og_membership_request
+field_name: og_membership_request
+entity_type: og_membership
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.node.group.yml
+++ b/config/sync/language.content_settings.node.group.yml
@@ -1,0 +1,11 @@
+uuid: 82537424-f653-45bb-a221-904ff7c64373
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node.group
+target_entity_type_id: node
+target_bundle: group
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.group.yml
+++ b/config/sync/node.type.group.yml
@@ -1,0 +1,17 @@
+uuid: ca00f962-6f22-435e-a418-5c946188d931
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Group
+type: group
+description: 'Allows you to create </em>group</em>'
+help: null
+new_revision: false
+preview_mode: 0
+display_submitted: false

--- a/config/sync/og.og_membership_type.default.yml
+++ b/config/sync/og.og_membership_type.default.yml
@@ -1,0 +1,9 @@
+uuid: b79bc72b-4fe7-4e6b-9722-bfa149691e6d
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 2XwlkUytFAWSvMmOhSbxRNu8xuGCMzPm2gqbfm3EqDY
+type: default
+name: Default
+description: 'Default OG membership type'

--- a/config/sync/og.og_role.node-group-administrator.yml
+++ b/config/sync/og.og_role.node-group-administrator.yml
@@ -1,0 +1,15 @@
+uuid: 25ea8011-8663-42b0-8a46-762a6876aa85
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node-group-administrator
+label: Administrator
+weight: 0
+group_id: null
+group_type: node
+group_bundle: group
+is_admin: true
+permissions: {  }
+role_type: null

--- a/config/sync/og.og_role.node-group-member.yml
+++ b/config/sync/og.og_role.node-group-member.yml
@@ -1,0 +1,15 @@
+uuid: 0e2a479e-1914-48a7-807f-469f3f741162
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node-group-member
+label: Member
+weight: 0
+group_id: null
+group_type: node
+group_bundle: group
+is_admin: false
+permissions: {  }
+role_type: required

--- a/config/sync/og.og_role.node-group-non-member.yml
+++ b/config/sync/og.og_role.node-group-non-member.yml
@@ -1,0 +1,16 @@
+uuid: b96fb0c9-6a7e-4371-97da-c707c6c8e697
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.group
+id: node-group-non-member
+label: Non-member
+weight: 0
+group_id: null
+group_type: node
+group_bundle: group
+is_admin: false
+permissions:
+  - subscribe
+role_type: required

--- a/config/sync/og.settings.yml
+++ b/config/sync/og.settings.yml
@@ -1,0 +1,16 @@
+_core:
+  default_config_hash: 3r2emFI83HVYv-o5sOIr3nycGMAXflzJR_3-8myD--k
+groups:
+  node:
+    - group
+group_manager_full_access: true
+node_access_strict: true
+delete_orphans: false
+delete_orphans_plugin_id: simple
+deny_subscribe_without_approval: true
+group_resolvers:
+  - route_group
+  - route_group_content
+  - request_query_argument
+  - user_access
+auto_add_group_owner_membership: true

--- a/config/sync/system.action.og_membership_add_multiple_roles_action.yml
+++ b/config/sync/system.action.og_membership_add_multiple_roles_action.yml
@@ -1,0 +1,13 @@
+uuid: 06de8044-1b86-46e6-8667-1fb3422ec144
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: F75n1v-BedKlOHARAWrmPevbBDfwZ1D1abXmyzna5IE
+id: og_membership_add_multiple_roles_action
+label: 'Add roles to the selected membership(s)'
+type: og_membership
+plugin: og_membership_add_multiple_roles_action
+configuration: {  }

--- a/config/sync/system.action.og_membership_add_single_role_action.administrator.yml
+++ b/config/sync/system.action.og_membership_add_single_role_action.administrator.yml
@@ -1,0 +1,12 @@
+uuid: 01d1fb30-3ff4-4066-b4c4-8438f9b42326
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+id: og_membership_add_single_role_action.administrator
+label: 'Add the administrator role to the selected members'
+type: og_membership
+plugin: og_membership_add_single_role_action
+configuration:
+  role_name: administrator

--- a/config/sync/system.action.og_membership_approve_pending_action.yml
+++ b/config/sync/system.action.og_membership_approve_pending_action.yml
@@ -1,0 +1,13 @@
+uuid: c6152996-bdef-447d-a0eb-8b1c344d8cbb
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: QF_8W18hb0Rg2z7yI_6w39-S-KBqqF2CabwsNZ_Xbig
+id: og_membership_approve_pending_action
+label: 'Approve the pending membership(s)'
+type: og_membership
+plugin: og_membership_approve_pending_action
+configuration: {  }

--- a/config/sync/system.action.og_membership_block_action.yml
+++ b/config/sync/system.action.og_membership_block_action.yml
@@ -1,0 +1,13 @@
+uuid: 04965d42-4e52-4b9d-bbd2-311e88fefd18
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: 6cd42ENzMv0J03pur_bmzP6i89rguku-oGJdm_tCOfc
+id: og_membership_block_action
+label: 'Block the selected membership(s)'
+type: og_membership
+plugin: og_membership_block_action
+configuration: {  }

--- a/config/sync/system.action.og_membership_delete_action.yml
+++ b/config/sync/system.action.og_membership_delete_action.yml
@@ -1,0 +1,13 @@
+uuid: 5fe10f58-b262-42dc-a7f6-a78c182bfcff
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: c2cdFgKVnpj_-UgkW-CcUExF0RFxrvFr0prqGRpL2V0
+id: og_membership_delete_action
+label: 'Delete the selected membership(s)'
+type: og_membership
+plugin: og_membership_delete_action
+configuration: {  }

--- a/config/sync/system.action.og_membership_remove_multiple_roles_action.yml
+++ b/config/sync/system.action.og_membership_remove_multiple_roles_action.yml
@@ -1,0 +1,13 @@
+uuid: 0f6c6bba-2e81-4741-9eab-187f3ed3c321
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: XqO143YCbRvYollUSUotKIvNcda297WFaE49W1Sj-JQ
+id: og_membership_remove_multiple_roles_action
+label: 'Remove roles from the selected membership(s)'
+type: og_membership
+plugin: og_membership_remove_multiple_roles_action
+configuration: {  }

--- a/config/sync/system.action.og_membership_remove_single_role_action.administrator.yml
+++ b/config/sync/system.action.og_membership_remove_single_role_action.administrator.yml
@@ -1,0 +1,12 @@
+uuid: d74aa812-9587-463e-b499-5a3eb7667a09
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+id: og_membership_remove_single_role_action.administrator
+label: 'Remove the administrator role from the selected members'
+type: og_membership
+plugin: og_membership_remove_single_role_action
+configuration:
+  role_name: administrator

--- a/config/sync/system.action.og_membership_unblock_action.yml
+++ b/config/sync/system.action.og_membership_unblock_action.yml
@@ -1,0 +1,13 @@
+uuid: 77245251-38f3-4e77-a031-640c03dc3cd8
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+_core:
+  default_config_hash: 7xXRUuE_2Kf2QLJwERtaiweMJMGbaNymsszUd9tqN08
+id: og_membership_unblock_action
+label: 'Unblock the selected membership(s)'
+type: og_membership
+plugin: og_membership_unblock_action
+configuration: {  }

--- a/config/sync/views.view.og_members_overview.yml
+++ b/config/sync/views.view.og_members_overview.yml
@@ -1,0 +1,608 @@
+uuid: d6ff41e9-c798-4f07-9e05-69e065ded384
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+    - options
+    - user
+_core:
+  default_config_hash: Ev8ZSruvdrE9i_AfeE1TleH4gnvUOpEXwXAGzyyGo2I
+id: og_members_overview
+label: 'Members overview'
+module: views
+description: 'Overview of the existing group members'
+tag: ''
+base_table: og_membership
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: none
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+          pagination_heading_level: h4
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            og_membership_bulk_form: og_membership_bulk_form
+            name: name
+          info:
+            og_membership_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        og_membership_bulk_form:
+          id: og_membership_bulk_form
+          table: og_membership
+          field: og_membership_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - og_membership_add_multiple_roles_action
+            - og_membership_approve_pending_action
+            - og_membership_block_action
+            - og_membership_delete_action
+            - og_membership_remove_multiple_roles_action
+            - og_membership_unblock_action
+          entity_type: og_membership
+          plugin_id: og_membership_bulk_form
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        created:
+          id: created
+          table: og_membership
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Member since'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: og_membership
+          entity_field: created
+          plugin_id: field
+        state:
+          id: state
+          table: og_membership
+          field: state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: State
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: og_membership
+          entity_field: state
+          plugin_id: field
+        roles_target_id:
+          id: roles_target_id
+          table: og_membership__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Roles
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: og_membership
+          entity_field: roles
+          plugin_id: field
+        operations:
+          id: operations
+          table: og_membership
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Operations links'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: og_membership
+          plugin_id: entity_operations
+      filters: {  }
+      sorts: {  }
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: 'No results text'
+          empty: true
+          tokenize: false
+          content: 'There are no members that belong to this group.'
+          plugin_id: text_custom
+      relationships:
+        uid:
+          id: uid
+          table: og_membership
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: true
+          entity_type: og_membership
+          entity_field: uid
+          plugin_id: standard
+      arguments:
+        entity_type:
+          id: entity_type
+          table: og_membership
+          field: entity_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: 'access denied'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: og_membership
+          entity_field: entity_type
+          plugin_id: string
+        entity_id:
+          id: entity_id
+          table: og_membership
+          field: entity_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: 'access denied'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: og_membership
+          entity_field: entity_id
+          plugin_id: string
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/server_default_content/content/node/0941e2ea-adb1-46d2-8123-c87142bf2710.yml
+++ b/web/modules/custom/server_default_content/content/node/0941e2ea-adb1-46d2-8123-c87142bf2710.yml
@@ -1,0 +1,68 @@
+_meta:
+  version: '1.0'
+  entity_type: node
+  uuid: 0941e2ea-adb1-46d2-8123-c87142bf2710
+  bundle: group
+  default_langcode: en
+default:
+  revision_uid:
+    -
+      target_id: 1
+  status:
+    -
+      value: true
+  uid:
+    -
+      target_id: 1
+  title:
+    -
+      value: 'Group A'
+  created:
+    -
+      value: 1757353568
+  promote:
+    -
+      value: false
+  sticky:
+    -
+      value: false
+  revision_translation_affected:
+    -
+      value: true
+  metatag:
+    -
+      tag: meta
+      attributes:
+        name: title
+        content: 'Group A | Drupal Starter'
+    -
+      tag: meta
+      attributes:
+        name: description
+        content: 'Loreum ipsum'
+    -
+      tag: link
+      attributes:
+        rel: canonical
+        href: 'http://drupal-starter.ddev.site:8880/node/1'
+    -
+      tag: meta
+      attributes:
+        property: 'og:title'
+        content: 'Group A'
+  path:
+    -
+      alias: ''
+      langcode: en
+      pathauto: 0
+  content_translation_source:
+    -
+      value: und
+  content_translation_outdated:
+    -
+      value: false
+  body:
+    -
+      value: '<p>Loreum ipsum</p>'
+      format: basic_html
+      summary: ''

--- a/web/modules/custom/server_default_content/server_default_content.info.yml
+++ b/web/modules/custom/server_default_content/server_default_content.info.yml
@@ -23,6 +23,8 @@ default_content:
     - e26f40ac-8dc2-4c25-990c-77e45399f09d # Li Europan lingues
     - f1dd02df-ef2f-4cc2-bd41-cf4ff0c34e01 # Current Digital Marketing Is...
     - fdfc2b97-a826-4887-8218-fb3a3add5f72 # Pandemic Moves Education Online
+    # Group A for backend test purposes.
+    - 0941e2ea-adb1-46d2-8123-c87142bf2710
 
   menu_link_content:
     - 5e0d5c87-84f9-4c98-abaa-d4c2df6eda73 # About

--- a/web/modules/custom/server_group/server_group.info.yml
+++ b/web/modules/custom/server_group/server_group.info.yml
@@ -1,0 +1,9 @@
+name: "Server Group"
+type: module
+description: "Server Group feature -- Organic Groups"
+core_version_requirement: ^9 || ^10
+package: "server"
+
+dependencies:
+  - drupal:og
+  - drupal:pluggable_entity_view_builder

--- a/web/modules/custom/server_group/server_group.module
+++ b/web/modules/custom/server_group/server_group.module
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * server_group.module
+ */
+
+/**
+ * Implements hook_theme().
+ */
+function server_group_theme($existing, $type, $theme, $path) {
+  return [
+    'server_group_subscribe_prompt' => [
+      'variables' => [
+        'name'  => NULL,
+        'label' => NULL,
+        'url'   => NULL,
+      ],
+    ],
+  ];
+}

--- a/web/modules/custom/server_group/server_group.routing.yml
+++ b/web/modules/custom/server_group/server_group.routing.yml
@@ -1,0 +1,8 @@
+server_group.group_join:
+  path: '/server-group/group/{node}/join'
+  defaults:
+    _controller: '\Drupal\server_group\Controller\JoinGroupController::join'
+    _title: 'Join group'
+  requirements:
+    _permission: 'access content'
+    node: '\d+'

--- a/web/modules/custom/server_group/src/Controller/JoinGroupController.php
+++ b/web/modules/custom/server_group/src/Controller/JoinGroupController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\server_group\Controller;
+
+use Drupal\Core\Url;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\node\NodeInterface;
+use Drupal\og\Og;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Controller for handling the "join group" action for OG groups.
+ *
+ * This controller ensures that the current user:
+ * - Is authenticated.
+ * - The node is a valid Organic Groups (OG) group.
+ * - Has permission to subscribe/create membership.
+ *
+ * If those conditions are met, it creates a new OG membership and redirects
+ * the user back to the requested destination or to the group node page.
+ */
+final class JoinGroupController extends ControllerBase {
+
+  /**
+   * Allows the current user to join an OG group.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node that represents the group.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect response to the requested destination (if available)
+   *   or to the group node page.
+   */
+  public function join(NodeInterface $node): RedirectResponse {
+    $account = $this->currentUser();
+
+    // Validate that the user is logged in and the node is a valid OG group.
+    if ($account->isAnonymous() || !Og::isGroup($node->getEntityTypeId(), $node->bundle())) {
+      $this->messenger()->addError($this->t('Not allowed.'));
+      return $this->redirect('<front>');
+    }
+
+    // Get OG services: membership manager and access checker.
+    $membership_manager = \Drupal::service('og.membership_manager');
+    $og_access = \Drupal::service('og.access');
+
+    // If the user is already a member, nothing new is created.
+    if ($membership_manager->isMember($node, $account)) {
+      $this->messenger()->addStatus($this->t('You are already a member of this group.'));
+      return $this->redirect('entity.node.canonical', ['node' => $node->id()]);
+    }
+
+    // Check OG permissions to allow subscribing to the group.
+    $allowed = $og_access->userAccess($node, 'subscribe', $account)->isAllowed()
+      || $og_access->userAccess($node, 'create og membership', $account)->isAllowed();
+
+    if (!$allowed) {
+      $this->messenger()->addError($this->t('You are not allowed to subscribe to this group.'));
+      return $this->redirect('entity.node.canonical', ['node' => $node->id()]);
+    }
+
+    // Load the full user entity (createMembership requires UserInterface).
+    $user_storage = $this->entityTypeManager()->getStorage('user');
+    $user = $user_storage->load($account->id());
+    if (!$user) {
+      $this->messenger()->addError($this->t('User not found.'));
+      return $this->redirect('entity.node.canonical', ['node' => $node->id()]);
+    }
+
+    // Create an active membership for this group and user.
+    $membership = $membership_manager->createMembership($node, $user);
+    $membership->save();
+
+    $this->messenger()->addStatus($this->t('Welcome! You have subscribed to %label.', ['%label' => $node->label()]));
+
+    // Redirect to the requested destination (if provided), or back to the group.
+    $destination = \Drupal::service('redirect.destination')->get();
+    if (!empty($destination)) {
+      return new RedirectResponse(
+        Url::fromUserInput($destination)->toString()
+      );
+    }
+    return $this->redirect('entity.node.canonical', ['node' => $node->id()]);
+  }
+
+}

--- a/web/modules/custom/server_group/src/Controller/JoinGroupController.php
+++ b/web/modules/custom/server_group/src/Controller/JoinGroupController.php
@@ -71,6 +71,10 @@ final class JoinGroupController extends ControllerBase {
     $membership = $membership_manager->createMembership($node, $user);
     $membership->save();
 
+    \Drupal::service('cache_tags.invalidator')->invalidateTags(
+      array_merge($node->getCacheTags(), $membership->getCacheTags())
+    );
+
     $this->messenger()->addStatus($this->t('Welcome! You have subscribed to %label.', ['%label' => $node->label()]));
 
     // Redirect to the requested destination (if provided), or back to the group.

--- a/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
+++ b/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
@@ -25,11 +25,8 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
 
     $current_user = \Drupal::currentUser();
 
-    // Only for OG groups.
+    // Extra safety: only act if this bundle is a registered OG group.
     if (!Og::isGroup($entity->getEntityTypeId(), $entity->bundle())) {
-      // Not a group: render normally.
-      // @todo: implement methods for rendering the rest of the fields.
-      $build[] = ['#markup' => $entity->label()];
       return $build;
     }
 
@@ -46,23 +43,30 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
     }
 
     $membership_manager = \Drupal::service('og.membership_manager');
-    $is_member = $membership_manager->isMember($entity, $current_user);
+    $og_access = \Drupal::service('og.access');
 
-    if (!$is_member) {
+    $is_member = $membership_manager->isMember($entity, $current_user);
+    // Check is NOT member and that the subscribe OG access is allowed.
+    if (!$is_member && $og_access->userAccess($entity, 'subscribe', $current_user)) {
       // Build subscribe prompt.
       $join_url = Url::fromRoute('server_group.group_join', [
         'node' => $entity->id(),
       ], ['query' => ['destination' => \Drupal::service('path.current')->getPath()]]);
 
       $build['server_group_subscribe_prompt'] = [
-        '#theme'  => 'server_group_subscribe_prompt',
-        '#name'   => $current_user->getDisplayName(),
-        '#label'  => $entity->label(),
-        '#url'    => $join_url->toString(),
-        '#cache'  => ['contexts' => ['user'], 'tags' => $entity->getCacheTags()],
+        '#theme' => 'server_group_subscribe_prompt',
+        '#name' => $current_user->getDisplayName(),
+        '#label' => $entity->label(),
+        '#url' => $join_url->toString(),
+        '#cache' => ['contexts' => ['user'], 'tags' => $entity->getCacheTags()],
       ];
-
     }
+    // Here means that effectively it has access to see content.
+    else {
+      // @todo: implement methods for rendering the rest of the fields.
+      $build[] = ['#markup' => $entity->label()];
+    }
+
     return $build;
   }
 

--- a/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
+++ b/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\server_group\Plugin\EntityViewBuilder;
+
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\og\Og;
+use Drupal\pluggable_entity_view_builder\EntityViewBuilderPluginAbstract;
+
+/**
+ * The "Node Group" plugin.
+ *
+ * @EntityViewBuilder(
+ *   id = "node.group",
+ *   label = @Translation("Node - Group"),
+ *   description = "Node view builder for Group bundle."
+ * )
+ */
+final class NodeGroup extends EntityViewBuilderPluginAbstract {
+
+  /**
+   * Build full view mode.
+   */
+  public function buildFull(array $build, NodeInterface $entity): array {
+
+    $current_user = \Drupal::currentUser();
+
+    // Only for OG groups.
+    if (!Og::isGroup($entity->getEntityTypeId(), $entity->bundle())) {
+      // Not a group: render normally.
+      // @todo: implement methods for rendering the rest of the fields.
+      $build[] = ['#markup' => $entity->label()];
+      return $build;
+    }
+
+    // Anonymous: only invite to subscribe (no body).
+    if ($current_user->isAnonymous()) {
+      $build['server_group_subscribe_prompt'] = [
+        '#markup' => $this->t('You must be an authenticated user and be in this group to view the content.'),
+        '#weight' => -1000,
+        '#cache' => [
+          'contexts' => ['user'],
+          'tags' => $entity->getCacheTags(),
+        ],
+      ];
+      return $build;
+    }
+
+    $membership_manager = \Drupal::service('og.membership_manager');
+    $is_member = $membership_manager->isMember($entity, $current_user);
+
+    if (!$is_member) {
+      // Build subscribe prompt.
+      $join_url = Url::fromRoute('server_group.group_join', [
+        'node' => $entity->id(),
+      ], ['query' => ['destination' => \Drupal::service('path.current')->getPath()]]);
+
+      $build['server_group_subscribe_prompt'] = [
+        '#theme'  => 'server_group_subscribe_prompt',
+        '#name'   => $current_user->getDisplayName(),
+        '#label'  => $entity->label(),
+        '#url'    => $join_url->toString(),
+        '#weight' => -1000,
+        '#cache'  => ['contexts' => ['user'], 'tags' => $entity->getCacheTags()],
+      ];
+
+    }
+    return $build;
+  }
+
+}

--- a/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
+++ b/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
@@ -37,7 +37,6 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
     if ($current_user->isAnonymous()) {
       $build['server_group_subscribe_prompt'] = [
         '#markup' => $this->t('You must be an authenticated user and be in this group to view the content.'),
-        '#weight' => -1000,
         '#cache' => [
           'contexts' => ['user'],
           'tags' => $entity->getCacheTags(),
@@ -60,7 +59,6 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
         '#name'   => $current_user->getDisplayName(),
         '#label'  => $entity->label(),
         '#url'    => $join_url->toString(),
-        '#weight' => -1000,
         '#cache'  => ['contexts' => ['user'], 'tags' => $entity->getCacheTags()],
       ];
 

--- a/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
+++ b/web/modules/custom/server_group/src/Plugin/EntityViewBuilder/NodeGroup.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\server_group\Plugin\EntityViewBuilder;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\og\Og;
@@ -30,6 +31,10 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
       return $build;
     }
 
+    // Ensure page varies per user and is tagged with the node.
+    $build['#cache']['contexts'] = array_unique(array_merge($build['#cache']['contexts'] ?? [], ['user']));
+    $build['#cache']['tags'] = Cache::mergeTags($build['#cache']['tags'] ?? [], $entity->getCacheTags());
+
     // Anonymous: only invite to subscribe (no body).
     if ($current_user->isAnonymous()) {
       $build['server_group_subscribe_prompt'] = [
@@ -47,7 +52,7 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
 
     $is_member = $membership_manager->isMember($entity, $current_user);
     // Check is NOT member and that the subscribe OG access is allowed.
-    if (!$is_member && $og_access->userAccess($entity, 'subscribe', $current_user)) {
+    if (!$is_member  || $og_access->userAccess($entity, 'subscribe', $current_user)->isAllowed()) {
       // Build subscribe prompt.
       $join_url = Url::fromRoute('server_group.group_join', [
         'node' => $entity->id(),
@@ -62,7 +67,9 @@ final class NodeGroup extends EntityViewBuilderPluginAbstract {
       ];
     }
     // Here means that effectively it has access to see content.
-    else {
+    // If a membership exists, add its cache tags so future changes invalidate.
+    else if ($membership = $membership_manager->getMembership($entity, $current_user)) {
+      $build['#cache']['tags'] = Cache::mergeTags($build['#cache']['tags'], $membership->getCacheTags());
       // @todo: implement methods for rendering the rest of the fields.
       $build[] = ['#markup' => $entity->label()];
     }

--- a/web/modules/custom/server_group/templates/server-group-subscribe-prompt.html.twig
+++ b/web/modules/custom/server_group/templates/server-group-subscribe-prompt.html.twig
@@ -1,6 +1,6 @@
 <div class="server-group-subscribe-prompt">
   Hi {{ name }},
-  <a href="{{ url }}">
+  <a class="server-group-subscribe-url" href="{{ url }}">
     {{ 'click here if you would like to subscribe to this group called'|t }} {{ label }}
   </a>.
 </div>

--- a/web/modules/custom/server_group/templates/server-group-subscribe-prompt.html.twig
+++ b/web/modules/custom/server_group/templates/server-group-subscribe-prompt.html.twig
@@ -1,0 +1,6 @@
+<div class="server-group-subscribe-prompt">
+  Hi {{ name }},
+  <a href="{{ url }}">
+    {{ 'click here if you would like to subscribe to this group called'|t }} {{ label }}
+  </a>.
+</div>

--- a/web/modules/custom/server_group/tests/src/ExistingSite/ServerGroupNodeGroupTest.php
+++ b/web/modules/custom/server_group/tests/src/ExistingSite/ServerGroupNodeGroupTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\Tests\server_group\ExistingSite;
+
+use Symfony\Component\HttpFoundation\Response;
+use Drupal\Tests\server_general\ExistingSite\ServerGeneralTestBase;
+
+/**
+ * Test 'group' for validating group access and membership
+ */
+class ServerGroupNodeGroupTest extends ServerGeneralTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function testSubscribeFlow() {
+    $user = $this->createUser();
+
+    // Create Group node.
+    $group_node = $this->createNode([
+      'title' => 'Drupal WOWs',
+      'type' => 'group',
+      'uid' => 1,
+      'body' => 'Loreum ipsum body here',
+    ]);
+    $group_node->save();
+    $group_node_url = $group_node->toUrl();
+
+    // Visit as anonymous.
+    $this->drupalGet($group_node_url);
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->pageTextContains('You must be an authenticated user and be in this group to view the content.');
+
+    // Visit as authenticated.
+    $this->drupalLogin($user);
+    $this->drupalGet($group_node_url);
+    $this->assertSession()->elementExists('css', '.server-group-subscribe-url');
+
+    // Simulate the click on subscribe link by going to this path.
+    $this->drupalGet('/server-group/group/' . $group_node->id() . '/join');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->pageTextContains('Welcome! You have subscribed to ' . $group_node->label() . '.');
+
+  }
+
+}


### PR DESCRIPTION
The Server Group module extends Organic Groups (OG) using the Pluggable Entity View Builder (PEVB) system.
It customizes how Group nodes are displayed and adds logic for membership management.
[Backend Test Task Walkthrough: Group Subscription and Content Access - Watch Video](https://www.loom.com/share/f1daf7c44b0d40daa3dcd469500e453f)

https://www.loom.com/share/f1daf7c44b0d40daa3dcd469500e453f


## Tests:

- When it's an anonymous user
- Go to node/1  it's a Group node
- The node is from Group A, which can only be viewed when the user is subscribed
- So when you log in as an anonymous user, you should see the following message:
- You must be an authenticated user and be in this group to view the content.
<img width="845" height="436" alt="image" src="https://github.com/user-attachments/assets/188fc3ac-c08e-4ffd-a2fc-7c2b214cbd59" />

- When it's an authenticated user
- Go to /node/1
- This user should see the following message:
- click here if you would like to subscribe to this group called'
<img width="708" height="308" alt="image" src="https://github.com/user-attachments/assets/317940f7-131f-4f4c-921e-cecd7a802b05" />

- You see this message because you are not yet subscribed to Group A
- And a link to subscribe to Group A should also appear
- When you click on the link, you should subscribe and view the node
<img width="625" height="278" alt="image" src="https://github.com/user-attachments/assets/6cdbea18-56df-432f-9ad8-65d82f7290f0" />
<img width="693" height="368" alt="image" src="https://github.com/user-attachments/assets/cd9e10d7-e12d-4c3b-9c64-fd36f62f3457" />
