### PR TITLE
Use admin theme for user utility pages

### DIFF
--- a/web/modules/custom/server_general/src/Routing/LockedPagesRouteSubscriber.php
+++ b/web/modules/custom/server_general/src/Routing/LockedPagesRouteSubscriber.php
@@ -19,6 +19,20 @@ use Symfony\Component\Routing\RouteCollection;
 final class LockedPagesRouteSubscriber extends RouteSubscriberBase {
 
   /**
+   * Utility user routes that should use the administration theme.
+   */
+  private const ADMIN_THEME_ROUTES = [
+    'entity.user.cancel_form',
+    'entity.user.canonical',
+    'entity.user.edit_form',
+    'user.cancel_confirm',
+    'user.edit',
+    'user.logout.confirm',
+    'user.page',
+    'user.well-known.change_password',
+  ];
+
+  /**
    * The route match service.
    *
    * @var \Drupal\Core\Routing\RouteMatchInterface
@@ -59,6 +73,12 @@ final class LockedPagesRouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
+    foreach (self::ADMIN_THEME_ROUTES as $route_name) {
+      if ($route = $collection->get($route_name)) {
+        $route->setOption('_admin_route', TRUE);
+      }
+    }
+
     // Check if the route exists and is for deleting a node.
     if ($route = $collection->get('entity.node.delete_form')) {
       $route->setRequirement('_custom_access', 'server_general.route_subscriber::access');

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralThemeNegotiatorTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralThemeNegotiatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifies utility account routes use the administration theme.
+ */
+final class ServerGeneralThemeNegotiatorTest extends ServerGeneralTestBase {
+
+  /**
+   * Tests utility user routes render with Claro while public pages do not.
+   */
+  public function testUserUtilityPagesUseAdminTheme(): void {
+    $user = $this->createUser();
+    $user->addRole('administrator');
+    $user->save();
+
+    $this->drupalLogin($user);
+
+    $this->drupalGet('/user');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertStringContainsString('/core/themes/claro/', $this->getSession()->getPage()->getContent());
+    $this->assertStringNotContainsString('/themes/custom/server_theme/dist/css/style.css', $this->getSession()->getPage()->getContent());
+
+    $this->drupalGet(sprintf('/user/%s', $user->id()));
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertStringContainsString('/core/themes/claro/', $this->getSession()->getPage()->getContent());
+    $this->assertStringNotContainsString('/themes/custom/server_theme/dist/css/style.css', $this->getSession()->getPage()->getContent());
+
+    $this->drupalGet('/search');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertStringContainsString('"theme":"server_theme"', $this->getSession()->getPage()->getContent());
+  }
+
+}


### PR DESCRIPTION
## Summary
- mark selected user utility/account routes as admin routes so they render with Claro
- keep public routes on server_theme to prevent frontend chrome bleeding into account pages
- add an ExistingSite regression test covering user utility routes and a public frontend route

## Evidence
Admin user utility page now renders with Claro:

![Admin user utility page](https://i.img402.dev/8fols7ur3u.png)

Public search page remains on server_theme:

![Public search page](https://i.img402.dev/enkenu7n2i.png)

## Testing
- ddev robo theme:compile-debug
- ddev phpunit --filter ServerGeneralThemeNegotiatorTest
- ddev phpcs
- ddev phpstan